### PR TITLE
Metadata parameter lowercase, request json field and others problems

### DIFF
--- a/src/Concerns/HasPermissions.php
+++ b/src/Concerns/HasPermissions.php
@@ -56,7 +56,7 @@ trait HasPermissions
 
         $data = json_decode($response->getBody()->getContents(), true);
 
-        $result = $data['result'] === "true";
+        $result = $data['result'] === 'true';
         $node = isset($data['node']) ? resolve(NodeMapper::class)->map($data['node']) : null;
 
         return new PermissionCheckResult($result, $node);

--- a/src/Concerns/HasPermissions.php
+++ b/src/Concerns/HasPermissions.php
@@ -39,7 +39,7 @@ trait HasPermissions
 
         if ($queryOptions !== null) {
             $response = $httpClient->post($route, [
-                'json' => [
+                'form_params' => [
                     $this->identifierMethod() => $this->identifier(),
                     'permission' => $permission,
                     'queryOptions' => $queryOptions->toArray(),
@@ -47,7 +47,7 @@ trait HasPermissions
             ]);
         } else {
             $response = $httpClient->get($route, [
-                'json' => [
+                'query' => [
                     $this->identifierMethod() => $this->identifier(),
                     'permission' => $permission,
                 ],

--- a/src/Concerns/HasPermissions.php
+++ b/src/Concerns/HasPermissions.php
@@ -56,10 +56,10 @@ trait HasPermissions
 
         $data = json_decode($response->getBody()->getContents(), true);
 
-        return new PermissionCheckResult(
-            $data['result'],
-            resolve(NodeMapper::class)->map($data['node']),
-        );
+        $result = $data['result'] === "true";
+        $node = isset($data['node']) ? resolve(NodeMapper::class)->map($data['node']) : null;
+
+        return new PermissionCheckResult($result, $node);
     }
 
     private function findRoute(): string

--- a/src/Group/GroupMapper.php
+++ b/src/Group/GroupMapper.php
@@ -12,7 +12,7 @@ class GroupMapper implements Mapper
             $data['name'],
             $data['displayName'],
             $data['weight'],
-            $data['metaData'],
+            $data['metadata'],
             $data['nodes'],
         );
     }

--- a/src/Group/GroupRepository.php
+++ b/src/Group/GroupRepository.php
@@ -33,7 +33,7 @@ class GroupRepository extends Repository
         return collect($this->json($response->getBody()->getContents()))->map(function ($userData) {
             return [
                 'name' => $userData['name'],
-                'results' => $userData['results']
+                'results' => $userData['results'],
             ];
         });
     }

--- a/src/Group/GroupRepository.php
+++ b/src/Group/GroupRepository.php
@@ -25,13 +25,16 @@ class GroupRepository extends Repository
     public function search(Search $search): Collection
     {
         $response = $this->session->httpClient->get('/group/search', [
-            'search' => $search->toArray(),
+            'query' => $search->toArray(),
         ]);
 
         $groupMapper = resolve(GroupMapper::class);
 
-        return collect($this->json($response->getBody()->getContents()))->map(function (array $group) use ($groupMapper) {
-            return $groupMapper->map($group);
+        return collect($this->json($response->getBody()->getContents()))->map(function ($userData) {
+            return [
+                'name' => $userData['name'],
+                'results' => $userData['results']
+            ];
         });
     }
 

--- a/src/Permission/PermissionCheckResult.php
+++ b/src/Permission/PermissionCheckResult.php
@@ -9,7 +9,8 @@ class PermissionCheckResult
     private bool $result;
     private ?Node $node;
 
-    public function __construct(bool $result, ?Node $node) {
+    public function __construct(bool $result, ?Node $node)
+    {
         $this->result = $result;
         $this->node = $node;
     }

--- a/src/Permission/PermissionCheckResult.php
+++ b/src/Permission/PermissionCheckResult.php
@@ -7,12 +7,9 @@ use LuckPermsAPI\Node\Node;
 class PermissionCheckResult
 {
     private bool $result;
-    private Node $node;
+    private ?Node $node;
 
-    public function __construct(
-        bool $result,
-        Node $node,
-    ) {
+    public function __construct(bool $result, ?Node $node) {
         $this->result = $result;
         $this->node = $node;
     }

--- a/src/User/UserMapper.php
+++ b/src/User/UserMapper.php
@@ -12,7 +12,7 @@ class UserMapper implements Mapper
             $data['username'],
             $data['uniqueId'],
             $data['nodes'],
-            $data['metaData'],
+            $data['metadata'],
         );
     }
 }

--- a/src/User/UserRepository.php
+++ b/src/User/UserRepository.php
@@ -25,13 +25,16 @@ class UserRepository extends Repository
     public function search(Search $search): Collection
     {
         $response = $this->session->httpClient->get('/user/search', [
-            'search' => $search->toArray(),
+            'query' => $search->toArray(),
         ]);
 
         $userMapper = resolve(UserMapper::class);
 
-        return collect($this->json($response->getBody()->getContents()))->map(function (array $user) use ($userMapper) {
-            return $userMapper->map($user);
+        return collect($this->json($response->getBody()->getContents()))->map(function ($userData) {
+            return [
+                'uniqueId' => $userData['uniqueId'],
+                'results' => $userData['results']
+            ];
         });
     }
 

--- a/src/User/UserRepository.php
+++ b/src/User/UserRepository.php
@@ -33,7 +33,7 @@ class UserRepository extends Repository
         return collect($this->json($response->getBody()->getContents()))->map(function ($userData) {
             return [
                 'uniqueId' => $userData['uniqueId'],
-                'results' => $userData['results']
+                'results' => $userData['results'],
             ];
         });
     }

--- a/tests/Group/GroupMapperTest.php
+++ b/tests/Group/GroupMapperTest.php
@@ -38,7 +38,7 @@ class GroupMapperTest extends TestCase {
                         'context' => [],
                     ]
                 ],
-                'metaData' => [
+                'metadata' => [
                     'meta' => [],
                 ],
             ],
@@ -59,7 +59,7 @@ class GroupMapperTest extends TestCase {
                         ],
                     ],
                 ],
-                'metaData' => [
+                'metadata' => [
                     'meta' => [],
                 ],
             ],

--- a/tests/Group/GroupRepositoryTest.php
+++ b/tests/Group/GroupRepositoryTest.php
@@ -74,7 +74,7 @@ class GroupRepositoryTest extends TestCase {
                 'name' => 'staff',
                 'displayName' => 'Staff',
                 'weight' => 1,
-                'metaData' => [
+                'metadata' => [
                     'meta' => [
                         'test' => 'test staff value',
                     ],
@@ -136,7 +136,7 @@ class GroupRepositoryTest extends TestCase {
                 'name' => 'staff',
                 'displayName' => 'Staff',
                 'weight' => 1,
-                'metaData' => [
+                'metadata' => [
                     'meta' => [
                         'test' => 'test staff value',
                     ],

--- a/tests/Permission/PermissionCheckTest.php
+++ b/tests/Permission/PermissionCheckTest.php
@@ -39,7 +39,7 @@ class PermissionCheckTest extends TestCase {
                         'context' => [],
                     ],
                 ],
-                'metaData' => [
+                'metadata' => [
                     'meta' => [],
                     'prefix' => '',
                     'suffix' => '',
@@ -87,7 +87,7 @@ class PermissionCheckTest extends TestCase {
                 'name' => 'default',
                 'displayName' => 'Default',
                 'weight' => 1,
-                'metaData' => [
+                'metadata' => [
                     'meta' => [],
                 ],
                 'nodes' => [
@@ -129,7 +129,7 @@ class PermissionCheckTest extends TestCase {
                 'name' => 'default',
                 'displayName' => 'Default',
                 'weight' => 1,
-                'metaData' => [
+                'metadata' => [
                     'meta' => [],
                 ],
                 'nodes' => [
@@ -205,7 +205,7 @@ class PermissionCheckTest extends TestCase {
                 'name' => 'default',
                 'displayName' => 'Default',
                 'weight' => 1,
-                'metaData' => [
+                'metadata' => [
                     'meta' => [],
                 ],
                 'nodes' => [

--- a/tests/User/UserRepositoryTest.php
+++ b/tests/User/UserRepositoryTest.php
@@ -106,7 +106,7 @@ class UserRepositoryTest extends TestCase {
                         ],
                     ],
                 ],
-                'metaData' => [
+                'metadata' => [
                     'meta' => [
                         'test' => 'test value',
                     ],
@@ -169,7 +169,7 @@ class UserRepositoryTest extends TestCase {
                         ],
                     ],
                 ],
-                'metaData' => [
+                'metadata' => [
                     'meta' => [
                         'test' => 'test value',
                     ],
@@ -182,7 +182,7 @@ class UserRepositoryTest extends TestCase {
                 'name' => 'staff',
                 'displayName' => 'Staff',
                 'weight' => 1,
-                'metaData' => [
+                'metadata' => [
                     'meta' => [
                         'test' => 'test staff value',
                     ],
@@ -211,7 +211,7 @@ class UserRepositoryTest extends TestCase {
                 'name' => 'member',
                 'displayName' => 'Meember!',
                 'weight' => 5,
-                'metaData' => [
+                'metadata' => [
                     'meta' => [
                         'test' => 'test meember value',
                     ],


### PR DESCRIPTION
Metadata parameter has been made lowercase by LuckPerms some time ago.
I honestly have no idea if anything else was changed.

(I saw now that you are a member of LuckPerms, I hope it is not an outdated wrapper because it would be very convenient for us)